### PR TITLE
Upgrade lowest symfony version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
         "ext-mbstring": "*",
         "spatie/flare-client-php": "dev-main",
         "monolog/monolog": "^2.0",
-        "symfony/console": "^5.0|^6.0",
-        "symfony/var-dumper": "^5.0|^6.0"
+        "symfony/console": "^5.4|^6.0",
+        "symfony/var-dumper": "^5.4|^6.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.4",
@@ -32,7 +32,7 @@
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpstan/phpstan-phpunit": "^1.0",
         "spatie/ray": "^1.32",
-        "symfony/process": "^5.2|^6.0"
+        "symfony/process": "^5.4|^6.0"
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
To my understanding this package is supopsed to work with Laravel 8 and 9, the lowest symfony versions employed by laravel 8 are the `5.4` versions, I upgraded the `composer.json` to align with that.
