### PR TITLE
Remove PHP 7.4 constraints

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest, windows-latest]
-                php: [7.4, 8.0, 8.1]
+                php: [8.0, 8.1]
                 stability: [prefer-lowest, prefer-stable]
 
         name: P${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "homepage": "https://flareapp.io/ignition",
     "license": "MIT",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "ext-mbstring": "*",
         "spatie/flare-client-php": "dev-main",


### PR DESCRIPTION
- Remove php 7.4 constraint from composer.json
- Do not test on unspoprted php versions
