### PR TITLE
Update incorrectly documented namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ interface HasSolutionsForThrowable
 {
     public function canSolve(Throwable $throwable): bool;
 
-    /** \Facade\Ignition\Contracts\Solution[] */
+    /** @return \Spatie\Ignition\Contracts\Solution[] */
     public function getSolutions(Throwable $throwable): array;
 }
 ```


### PR DESCRIPTION
This old Facade namespace in the docs is wrong - this just fixes it.