### PR TITLE
Ensure example exception is... an exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ the exception gets thrown.
 use Spatie\Ignition\Contracts\Solution;
 use Spatie\Ignition\Contracts\ProvidesSolution;
 
-class CustomException implements ProvidesSolution
+class CustomException extends Exception implements ProvidesSolution
 {
     public function getSolution(): Solution
     {


### PR DESCRIPTION
Spotted this typo in the docs where the example exception doesn't extend the base one, so wouldn't work if just copy+pasting it.