### PR TITLE
Render theme class in HTML

### DIFF
--- a/resources/views/errorPage.php
+++ b/resources/views/errorPage.php
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <?php /** @var \Spatie\Ignition\ErrorPage\ErrorPageViewModel $viewModel */ ?>
-<html lang="en">
+<html lang="en" class="<?= $viewModel->config()['theme'] ?? '' ?>">
 <!--
 <?= $viewModel->throwableString() ?>
 -->


### PR DESCRIPTION
Fixes https://github.com/spatie/laravel-ignition/issues/26 by rendering the theme class sooner via the HTML output instead of via JS.

@AlexVanderbist might need some PHP love