### PR TITLE
add check to make sure ConfigFilePath is readable

### DIFF
--- a/src/Config/DefaultConfigFinder.php
+++ b/src/Config/DefaultConfigFinder.php
@@ -11,6 +11,7 @@ class DefaultConfigFinder
         }
 
         $filepath = "{$homeDirectory}/.ignition.json";
+        
         return @is_readable($filepath) ? $filepath : '';
     }
 

--- a/src/Config/DefaultConfigFinder.php
+++ b/src/Config/DefaultConfigFinder.php
@@ -10,7 +10,8 @@ class DefaultConfigFinder
             return '';
         }
 
-        return "{$homeDirectory}/.ignition.json";
+        $filepath = "{$homeDirectory}/.ignition.json";
+        return @is_readable($filepath) ? $filepath : '';
     }
 
     protected function findHomeDirectory(): ?string


### PR DESCRIPTION
This is to prevent open_basedir restriction errors when the HomeDirectory isn't accessible. Fix for issue https://github.com/spatie/ignition/issues/22