### PR TITLE
Refine the Windows OS check

### DIFF
--- a/src/Config/DefaultConfigFinder.php
+++ b/src/Config/DefaultConfigFinder.php
@@ -17,7 +17,7 @@ class DefaultConfigFinder
 
     protected function findHomeDirectory(): ?string
     {
-        if (str_starts_with(PHP_OS, 'WIN')) {
+        if (str_starts_with(strtoupper(PHP_OS), 'WIN')) {
             if (empty($_SERVER['HOMEDRIVE']) || empty($_SERVER['HOMEPATH'])) {
                 return null;
             }

--- a/src/Config/DefaultConfigFinder.php
+++ b/src/Config/DefaultConfigFinder.php
@@ -17,7 +17,7 @@ class DefaultConfigFinder
 
     protected function findHomeDirectory(): ?string
     {
-        if (str_starts_with(strtoupper(PHP_OS), 'WIN')) {
+        if ($this->isWindows()) {
             if (empty($_SERVER['HOMEDRIVE']) || empty($_SERVER['HOMEPATH'])) {
                 return null;
             }
@@ -32,5 +32,10 @@ class DefaultConfigFinder
         }
 
         return null;
+    }
+
+    private function isWindows(): bool
+    {
+        return str_starts_with(strtoupper(PHP_OS), 'WIN');
     }
 }


### PR DESCRIPTION
Hello,

I would like to propose a little refinement to Windows OS check. It seems that one of the possible values of PHP_OS constant could be `Windows`. Therefore, it might be better to convert its value to the uppercase before comparing.