### PR TITLE
fix: Convert query bindings to an array before mapping

### DIFF
--- a/resources/js/index.tsx
+++ b/resources/js/index.tsx
@@ -58,7 +58,7 @@ function transformIgnitionError({ report, solutions }: IgniteData): ErrorOccurre
                       value: {
                           ...query,
                           replace_bindings: true,
-                          bindings: query.bindings.map((binding) => ({
+                          bindings: Object.values(query.bindings).map((binding) => ({
                               type: typeof binding,
                               value: binding,
                           })),


### PR DESCRIPTION
Fixes #42

This PR fixes an issue where Ignition would crash and show an empty page when a query would have a `bindings` object instead of the currently expect array. 

The fix is to use `Object.values` to get the values, which work on both arrays and objects.