### PR TITLE
fix: don't let `exception_message` be `null`

### DIFF
--- a/resources/js/index.tsx
+++ b/resources/js/index.tsx
@@ -130,7 +130,7 @@ function transformIgnitionError({ report, solutions }: IgniteData): ErrorOccurre
         received_at: new Date(report.seen_at * 1000).toISOString(),
         seen_at_url: report?.context?.request?.url,
         exception_class: report.exception_class,
-        exception_message: report.message,
+        exception_message: report.message || '',
         application_path: report.application_path,
         application_version: report.application_version,
         language_version: report.language_version,


### PR DESCRIPTION
This PR fixes an issue that happens when `exception_message` is `null`. In that case, Ignition crashes and nothing is displayed on screen.

## Context

I had an issue in my code, where I was reading a file (with `Storage::disk('public')->get('file.pdf')`) and returning `response()->file($file)` instead of using `->path($file)`.

This resulted in a `Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException` exception, but the content of `$path` was the content of the file, which in this case was a whole PDF. 

My stacktrace was the following:

```
15:49:35.978 Uncaught TypeError: can't access property "match", t is null
    h https://localnova.local/make-pdf#F58:46
    Fc https://localnova.local/make-pdf#F58:46
    unstable_runWithPriority https://localnova.local/make-pdf#F58:46
    Qa https://localnova.local/make-pdf#F58:46
    Dc https://localnova.local/make-pdf#F58:46
    bc https://localnova.local/make-pdf#F58:46
    to https://localnova.local/make-pdf#F58:46
    unstable_runWithPriority https://localnova.local/make-pdf#F58:46
    Qa https://localnova.local/make-pdf#F58:46
    to https://localnova.local/make-pdf#F58:46
    eo https://localnova.local/make-pdf#F58:46
    Tc https://localnova.local/make-pdf#F58:46
    lu https://localnova.local/make-pdf#F58:46
    render https://localnova.local/make-pdf#F58:46
    ignite https://localnova.local/make-pdf#F58:46
    <anonymous> https://localnova.local/make-pdf#F58:50
make-pdf:46:358124
```

Note that trying to fix the issue here was not working:

 https://github.com/spatie/ignition/blob/d2d5ba823af3004268556e87dfc94449e4159f5a/resources/js/components/NavBar.tsx#L170

In the compiled JS, there is 3 occurrences of `exception_message`, while there is only 2 in the source code, so I just changed the initialization of `ErrorOccurrence`.