### PR TITLE
fix exception caused by file_exists

### DIFF
--- a/src/Config/FileConfigManager.php
+++ b/src/Config/FileConfigManager.php
@@ -41,7 +41,7 @@ class FileConfigManager implements ConfigManager
 
     protected function isValidWritablePath(string $path): bool
     {
-        return file_exists($path) && @is_writable($path);
+        return @file_exists($path) && @is_writable($path);
     }
 
     protected function preparePath(string $path): string


### PR DESCRIPTION
Hello there,

#57 didn't handle suprpess file_exists exception when the homedir is outside the open_basedir allowed paths in the `isValidWritablePath` function