### PR TITLE
Suppress file check

### DIFF
--- a/src/Config/FileConfigManager.php
+++ b/src/Config/FileConfigManager.php
@@ -113,7 +113,7 @@ class FileConfigManager implements ConfigManager
             return false;
         }
 
-        if (file_exists($this->file)) {
+        if (@file_exists($this->file)) {
             return true;
         }
 

--- a/src/Config/FileConfigManager.php
+++ b/src/Config/FileConfigManager.php
@@ -88,7 +88,7 @@ class FileConfigManager implements ConfigManager
     protected function isValidFile(): bool
     {
         return $this->isValidPath() &&
-            file_exists($this->file) &&
+            @file_exists($this->file) &&
             @is_writable($this->file);
     }
 


### PR DESCRIPTION
Hello again,

I didn't think, that file_exists() and is_writable() without a supression can [cause some troules](https://github.com/spatie/ignition/pull/90) (according to the documentation it emitts E_WARNING). So, this PR suppresses all possible checks in the file.