### PR TITLE
Remove monolog

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "spatie/flare-client-php": "^1.0|dev-l10",
-        "monolog/monolog": "^2.0",
         "symfony/console": "^5.4|^6.0",
         "symfony/var-dumper": "^5.4|^6.0"
     },


### PR DESCRIPTION
Laravel v10 will require Monolog v3. Right now, there doesn't seems to be any usage if Monolog in this specific library. 

After this is merged I'll send in a PR to spatie/laravel-ignition:dev-l10 to update Monolog there.
