### PR TITLE
[PHP 8.2] Fix `${var}` string interpolation deprecation

### DIFF
--- a/src/Solutions/SolutionProviders/MergeConflictSolutionProvider.php
+++ b/src/Solutions/SolutionProviders/MergeConflictSolutionProvider.php
@@ -48,7 +48,7 @@ class MergeConflictSolutionProvider implements HasSolutionsForThrowable
 
     protected function getCurrentBranch(string $directory): string
     {
-        $branch = "'".trim((string)shell_exec("cd ${directory}; git branch | grep \\* | cut -d ' ' -f2"))."'";
+        $branch = "'".trim((string)shell_exec("cd {$directory}; git branch | grep \\* | cut -d ' ' -f2"))."'";
 
         if ($branch === "''") {
             $branch = 'current branch';


### PR DESCRIPTION
PHP 8.2 deprecates `"${var}"` string interpolation pattern.
This fixes the only such occurrence in `spatie/ignition` package.

 - [PHP 8.2: `${var}` string interpolation deprecated](https://php.watch/versions/8.2/${var}-string-interpolation-deprecated)
 - [RFC](https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation)