### PR TITLE
Add refresh capabilites of vitejs

### DIFF
--- a/resources/views/errorPage.php
+++ b/resources/views/errorPage.php
@@ -30,6 +30,11 @@
         }
     </script>
 
+
+    <?php if (class_exists('Illuminate\Foundation\Vite') && is_file(base_path('vite.config.js')) && is_file(public_path('/hot'))): ?>
+        <?= app(\Illuminate\Foundation\Vite::class)->__invoke([]) ?>
+    <?php endif; ?>
+
     <style><?= $viewModel->getAssetContents('ignition.css') ?></style>
 
 </head>

--- a/resources/views/errorPage.php
+++ b/resources/views/errorPage.php
@@ -30,7 +30,6 @@
         }
     </script>
 
-
     <?php if (class_exists('Illuminate\Foundation\Vite') && is_file(base_path('vite.config.js')) && is_file(public_path('/hot'))): ?>
         <?= app(\Illuminate\Foundation\Vite::class)->__invoke([]) ?>
     <?php endif; ?>


### PR DESCRIPTION
Hey!

I often encounter the Problem while developing that I run into an error and then I need to manually reload the page after correcting the error. Using ViteJS it is already possible to reload the page automatically on file save and I would love it, if there is a way for auto reloading the error page to check if the code is running correctly.

Right now Ignition doesn't include a way to dynamically add scripts to the error page and I don't know if this is wished for and therefor simply wrote the part where the Vite Client Module is included using the Laravel Vite Helper (which don't exist in non-laravel projects)

What is your opinion on the problem?
(Solution is probably not the best way to go, but it works locally for me 😄)