### PR TITLE
Improve solution provider repo interface

### DIFF
--- a/src/Contracts/SolutionProviderRepository.php
+++ b/src/Contracts/SolutionProviderRepository.php
@@ -6,10 +6,15 @@ use Throwable;
 
 interface SolutionProviderRepository
 {
-    public function registerSolutionProvider(string $solutionProviderClass): self;
+    /**
+     * @param class-string<ProvidesSolution>|ProvidesSolution $solutionProviderClass
+     *
+     * @return $this
+     */
+    public function registerSolutionProvider(string|ProvidesSolution $solutionProviderClass): self;
 
     /**
-     * @param array<int,class-string<ProvidesSolution>|ProvidesSolution> $solutionProviderClasses
+     * @param array<class-string<ProvidesSolution>|ProvidesSolution> $solutionProviderClasses
      *
      * @return $this
      */
@@ -22,5 +27,10 @@ interface SolutionProviderRepository
      */
     public function getSolutionsForThrowable(Throwable $throwable): array;
 
+    /**
+     * @param class-string<Solution> $solutionClass
+     *
+     * @return null|Solution
+     */
     public function getSolutionForClass(string $solutionClass): ?Solution;
 }

--- a/src/Solutions/SolutionProviders/SolutionProviderRepository.php
+++ b/src/Solutions/SolutionProviders/SolutionProviderRepository.php
@@ -88,7 +88,7 @@ class SolutionProviderRepository implements SolutionProviderRepositoryContract
     protected function initialiseSolutionProviderRepositories(): Collection
     {
         return $this->solutionProviders
-            ->filter(fn(HasSolutionsForThrowable|string $provider) => in_array(HasSolutionsForThrowable::class, class_implements($provider) ?: []))
+            ->filter(fn (HasSolutionsForThrowable|string $provider) => in_array(HasSolutionsForThrowable::class, class_implements($provider) ?: []))
             ->map(function (string|HasSolutionsForThrowable $provider) {
                 if (is_string($provider)) {
                     return new $provider;

--- a/src/Solutions/SolutionProviders/SolutionProviderRepository.php
+++ b/src/Solutions/SolutionProviders/SolutionProviderRepository.php
@@ -11,16 +11,16 @@ use Throwable;
 
 class SolutionProviderRepository implements SolutionProviderRepositoryContract
 {
-    /** @var Collection<int, class-string<HasSolutionsForThrowable>> */
+    /** @var Collection<int, class-string<HasSolutionsForThrowable>|HasSolutionsForThrowable> */
     protected Collection $solutionProviders;
 
-    /** @param array<int, class-string<HasSolutionsForThrowable>> $solutionProviders */
+    /** @param array<int, class-string<HasSolutionsForThrowable>|HasSolutionsForThrowable> $solutionProviders */
     public function __construct(array $solutionProviders = [])
     {
         $this->solutionProviders = Collection::make($solutionProviders);
     }
 
-    public function registerSolutionProvider(string $solutionProviderClass): SolutionProviderRepositoryContract
+    public function registerSolutionProvider(string|ProvidesSolution $solutionProviderClass): SolutionProviderRepositoryContract
     {
         $this->solutionProviders->push($solutionProviderClass);
 
@@ -46,32 +46,19 @@ class SolutionProviderRepository implements SolutionProviderRepositoryContract
             $solutions[] = $throwable->getSolution();
         }
 
-        $providedSolutions = $this->solutionProviders
-            ->filter(function (string $solutionClass) {
-                if (! in_array(HasSolutionsForThrowable::class, class_implements($solutionClass) ?: [])) {
-                    return false;
-                }
-
-                /*
-                if (in_array($solutionClass, config('ignition.ignored_solution_providers', []))) {
-                    return false;
-                }
-                */
-
-                return true;
-            })
-            ->map(fn (string $solutionClass) => new $solutionClass)
+        $providedSolutions = $this
+            ->initialiseSolutionProviderRepositories()
             ->filter(function (HasSolutionsForThrowable $solutionProvider) use ($throwable) {
                 try {
                     return $solutionProvider->canSolve($throwable);
-                } catch (Throwable $e) {
+                } catch (Throwable $exception) {
                     return false;
                 }
             })
             ->map(function (HasSolutionsForThrowable $solutionProvider) use ($throwable) {
                 try {
                     return $solutionProvider->getSolutions($throwable);
-                } catch (Throwable $e) {
+                } catch (Throwable $exception) {
                     return [];
                 }
             })
@@ -96,5 +83,18 @@ class SolutionProviderRepository implements SolutionProviderRepositoryContract
         }
 
         return app($solutionClass);
+    }
+
+    protected function initialiseSolutionProviderRepositories(): Collection
+    {
+        return $this->solutionProviders
+            ->filter(fn(HasSolutionsForThrowable|string $provider) => in_array(HasSolutionsForThrowable::class, class_implements($provider) ?: []))
+            ->map(function (string|HasSolutionsForThrowable $provider) {
+                if (is_string($provider)) {
+                    return new $provider;
+                }
+
+                return $provider;
+            });
     }
 }

--- a/tests/IgnitionTest.php
+++ b/tests/IgnitionTest.php
@@ -21,11 +21,22 @@ test('flare middleware can be added to ignition', function () {
     expect($report->getMessage())->toEqual('Original message, now modified');
 });
 
-test('custom solution providers can be added', function () {
+test('custom solution providers can be added as FQCN', function () {
     $report = $this->ignition
         ->addSolutionProviders([
             AlwaysFalseSolutionProvider::class,
             AlwaysTrueSolutionProvider::class,
+        ])
+        ->handleException(new Exception('Hey'));
+
+    expect($report->toArray()['solutions'][0]['title'])->toEqual('My custom solution');
+});
+
+test('custom solution providers can be added as instances', function () {
+    $report = $this->ignition
+        ->addSolutionProviders([
+            new AlwaysFalseSolutionProvider,
+            new AlwaysTrueSolutionProvider,
         ])
         ->handleException(new Exception('Hey'));
 


### PR DESCRIPTION
This PR updates the (internal) `SolutionProviderRepository` interface to allow instances of SolutionProviders to be passed to the solution provider repo like the doc blocks suggest.

Closes #121 