### PR TITLE
fix: use comments to allow proper loading of script

### DIFF
--- a/resources/views/errorPage.php
+++ b/resources/views/errorPage.php
@@ -57,7 +57,9 @@
 <div id="app"></div>
 
 <script>
-<?= $viewModel->getAssetContents('ignition.js') ?>
+    <!--
+    <?= $viewModel->getAssetContents('ignition.js') ?>
+    -->
 </script>
 
 <script>


### PR DESCRIPTION
Right now, whenever an error occurs it just shows me a lot of JavaScript code:
![image](https://user-images.githubusercontent.com/5358638/199445706-d63966ed-81aa-4d40-a3b1-a8b4795b1f58.png)

When I had a look at the DOM tree I saw that the script tag is suddenly closed:
![image](https://user-images.githubusercontent.com/5358638/199445929-3a751f20-e961-4fff-8863-b24fb704b56c.png)

It seems that the following line in the script is closing the tag too early:
````javascript
;(c.innerHTML = '<script></script>'),
````

Using comments as a wrapper of the script it does not close the script and it's working perfectly fine.