### PR TITLE
Removes monolog dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
         "php": "^8.0",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "monolog/monolog": "^2.0",
         "spatie/flare-client-php": "^1.0|dev-l10",
         "symfony/console": "^5.4|^6.0",
         "symfony/var-dumper": "^5.4|^6.0"


### PR DESCRIPTION
Seems that this library don't have a direct or indirect on Monolog. Therefore, this dependency can be safely removed.

This pull request also fixes the installation of ignition on Laravel 10.