### PR TITLE
Add PHPStorm via IDE Remote Control plugin link option

### DIFF
--- a/src/Config/IgnitionConfig.php
+++ b/src/Config/IgnitionConfig.php
@@ -170,6 +170,10 @@ class IgnitionConfig implements Arrayable
                     'label' => 'PhpStorm',
                     'url' => 'phpstorm://open?file=%path&line=%line',
                 ],
+                'phpstorm-remote' => [
+                    'label' => 'PHPStorm Remote',
+                    'url' => 'http://localhost:63342/api/file/%path:%line',
+                ],
                 'idea' => [
                     'label' => 'Idea',
                     'url' => 'idea://open?file=%path&line=%line',


### PR DESCRIPTION
Fixes https://github.com/spatie/laravel-ignition/issues/141

I hope that's enough? I **think** the github resources pipeline compiles the js for the dropdown..?

If this is merged I'll PR a change for this comment as well:
https://github.com/spatie/laravel-ignition/blob/c21309ebf6657e0c38083afac8af9baa12885676/config/ignition.php#L35