### PR TITLE
Correct URL path and line link for Panic's Nova editor

### DIFF
--- a/src/Config/IgnitionConfig.php
+++ b/src/Config/IgnitionConfig.php
@@ -200,7 +200,7 @@ class IgnitionConfig implements Arrayable
                 ],
                 'nova' => [
                     'label' => 'Nova',
-                    'url' => 'nova://core/open/file?filename=%path&line=%line',
+                    'url' => 'nova://open?path=%path&line=%line',
                 ],
                 'netbeans' => [
                     'label' => 'NetBeans',


### PR DESCRIPTION
Update the URL to be correct as it currently doesn't work. Not sure it ever worked but this has been tested against most recent release.

https://nova.app/releases/