### PR TITLE
Add Windows support for persistent config

### DIFF
--- a/src/Config/FileConfigManager.php
+++ b/src/Config/FileConfigManager.php
@@ -59,6 +59,10 @@ class FileConfigManager implements ConfigManager
             return getenv('HOME');
         }
 
+        if (! empty($_SERVER['DOCUMENT_ROOT'])) {
+            return preg_replace('/public$/', '', $_SERVER['DOCUMENT_ROOT']);
+        }
+
         return '';
     }
 


### PR DESCRIPTION
This PR fixes an issue for Windows users, that causes config setting persistence to (silently) fail. Previously, when trying to save Ignition settings from an exception screen, the request to `/_ignition/update-config` succeeds with a `200` status code, but the actual response is just `false` since the directory (ie, environment path) is not valid:

![ignition](https://github.com/spatie/ignition/assets/13950848/270e64a3-fd2f-46fc-8a44-ed832e92cdb5)

The additional check added to the `initPathFromEnvironment` method accounts for the missing `HOMEDRIVE` and `HOMEPATH` server variables, as well as the `HOME` env variable, and generates/reads config settings for Windows users as needed.

Thanks for your consideration, here!