### PR TITLE
Do not interfere with errors that were suppressed by the @ operator.

### DIFF
--- a/src/Ignition.php
+++ b/src/Ignition.php
@@ -267,6 +267,12 @@ class Ignition
         int $line = 0,
         array $context = []
     ): void {
+        if(error_reporting() === (E_ERROR | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR | E_PARSE)) {
+            // This happens when PHP version is >=8 and we caught an error that was suppressed with the "@" operator
+            // See the first warning box in https://www.php.net/manual/en/language.operators.errorcontrol.php
+            return;
+        }
+
         throw new ErrorException($message, 0, $level, $file, $line);
     }
 

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -28,6 +28,18 @@ it('will not render if everything ran ok', function () {
     expect($output)->toEqual('ok');
 });
 
+it('can render the error page for unsuppressed errors', function () {
+    $output = getOutputOfApp('unsuppressed-error.php');
+
+    expect($output)->toContain('window.ignite');
+});
+
+it('will not render if an error was explicitly suppressed', function () {
+    $output = getOutputOfApp('suppressed-error.php');
+
+    expect($output)->toEqual('ok');
+});
+
 it('can show a solution', function () {
     $output = getOutputOfApp('exception-with-solution.php');
 

--- a/tests/stubs/apps/suppressed-error.php
+++ b/tests/stubs/apps/suppressed-error.php
@@ -1,0 +1,11 @@
+<?php
+
+use Spatie\Ignition\Ignition;
+
+include('../../../vendor/autoload.php');
+
+Ignition::make()->register();
+
+@include('./file-not-found.txt');
+
+echo 'ok';

--- a/tests/stubs/apps/unsuppressed-error.php
+++ b/tests/stubs/apps/unsuppressed-error.php
@@ -1,0 +1,11 @@
+<?php
+
+use Spatie\Ignition\Ignition;
+
+include('../../../vendor/autoload.php');
+
+Ignition::make()->register();
+
+include('./file-not-found.txt');
+
+echo 'ok';


### PR DESCRIPTION
While working on a legacy project, I noticed that execution threw a different set of error when Ignition was enabled. I noticed that the project makes use of the "@" operator, which suppresses some errors. Ignition is not taking this into consideration, and it will throw new exceptions even for suppressed errors.

This is because when you register an error handler, it will fire regardless of error suppressions, and one should check for a magic error_reporting value to detect that it was indeed suppressed. If the error is _not_ being suppressed, then this value will be -1, as we set it originally.

My code checks for that special value, and if it finds it it return immediately, so Ignition does not fire.