### PR TITLE
Add noopener and noreferrer to external URLs

### DIFF
--- a/resources/js/components/AppDebugWarning.tsx
+++ b/resources/js/components/AppDebugWarning.tsx
@@ -30,6 +30,7 @@ export default function AppDebugWarning() {
                     <a
                         className="mt-1.5 underline inline-flex items-center gap-2"
                         target="_blank"
+                        rel="noopener noreferrer"
                         href="https://flareapp.io/docs/ignition-for-laravel/security"
                     >
                         <FontAwesomeIcon icon={faShieldAlt} className="text-sm opacity-50" />

--- a/resources/js/components/FlareFooter.tsx
+++ b/resources/js/components/FlareFooter.tsx
@@ -19,6 +19,7 @@ export default function FlareFooter() {
                             <a
                                 href="https://flareapp.io/?utm_campaign=ignition&utm_source=ignition"
                                 target="_blank"
+                                rel="noopener noreferrer"
                                 className="rounded-md bg-white px-3.5 py-2.5 text-sm font-semibold text-gray-900 shadow-sm hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
                             >
                                 Learn more <span aria-hidden="true">→</span>

--- a/resources/js/components/NavBarItem.tsx
+++ b/resources/js/components/NavBarItem.tsx
@@ -36,7 +36,12 @@ export default function NavBarItem({
 
     return (
         <li ref={navRef}>
-            <a href={href || `#${name}`} target={href ? '_blank' : '_self'} onClick={onClickHandler}>
+            <a
+                href={href || `#${name}`}
+                target={href ? '_blank' : '_self'}
+                onClick={onClickHandler}
+                rel={href ? 'noopener noreferrer' : ''}
+            >
                 <button
                     className={`
                     group px-3 sm:px-5 h-10 uppercase tracking-wider text-xs font-medium

--- a/resources/js/components/SettingsDropdown.tsx
+++ b/resources/js/components/SettingsDropdown.tsx
@@ -110,6 +110,7 @@ export default function SettingsDropdown({ isOpen }: Props) {
                         className="text-xs ~text-gray-500 hover:text-red-500 flex items-center underline transition-colors"
                         href="https://flareapp.io/ignition?utm_campaign=ignition&utm_source=ignition"
                         target="_blank"
+                        rel="noopener noreferrer"
                     >
                         Docs
                         <IgnitionIcon />

--- a/resources/js/components/ShareDropdown.tsx
+++ b/resources/js/components/ShareDropdown.tsx
@@ -52,7 +52,7 @@ export default function ShareDropdown({ isOpen }: Props) {
         try {
             const response = await shareClient(igniteData, selectedSectionNames);
 
-            window.open(response.owner_url);
+            window.open(response.owner_url, '_blank', 'noopener,noreferrer');
 
             setPublicUrl(response.public_url);
         } catch (e) {
@@ -78,6 +78,7 @@ export default function ShareDropdown({ isOpen }: Props) {
                         className="text-xs ~text-gray-500 hover:text-violet-500 flex items-center underline transition-colors"
                         href="https://flareapp.io/docs/ignition/introducing-ignition/sharing-errors?utm_campaign=ignition&utm_source=ignition"
                         target="_blank"
+                        rel="noopener noreferrer"
                     >
                         Docs
                         <FlareIcon />

--- a/resources/js/components/ui/CopyableUrl.tsx
+++ b/resources/js/components/ui/CopyableUrl.tsx
@@ -17,6 +17,7 @@ export default function CopyableUrl({url, openText, helpText}: Props) {
                 <a
                     href={url}
                     target="_blank"
+                    rel="noopener noreferrer"
                     className="underline ~text-violet-500 hover:~text-violet-600"
                 >
                     <FontAwesomeIcon icon={faExternalLinkAlt} className="opacity-50 text-xs mr-1"/>


### PR DESCRIPTION
This adds `rel="noopener noreferrer"` to external URLs. Technically `noopener` is not needed for newer browsers, because they set it automatically when `target="_blank"`, but to me it still seems like a nice thing to not send the referrer along. 

If the opener is sent along it could potentially also be used in a destructive way. Ignition previously had a RCE vulnerability, if any of the external links contain malicious JS, combined with an RCE it could lead to some bad things. If I'm not mistaken Ignition still has the ability to adjust code (solutions), so IMHO applying these anchor attributes would be good security-wise. Better safe than sorry :)

https://mathiasbynens.github.io/rel-noopener/

Accompanying PR for ignition-ui: spatie/ignition-ui#17