### PR TITLE
Added OpenMage module for Ignition to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ For Symfony apps, go to [symfony-ignition-bundle](https://github.com/spatie/symf
 
 For Drupal 10+ websites, use the [Ignition module](https://www.drupal.org/project/ignition).
 
+For OpenMage websites, use the [Ignition module](https://github.com/empiricompany/openmage_ignition).
+
 For all other PHP projects, install the package via composer:
 
 ```bash


### PR DESCRIPTION
With the [OpenMage](http://github.com/openmage/magento-lts/) (community fork of Magento 1) team we worked to create a module for Ignition and it would be great to have it listed here.

The module supports Flare and OpenAI solutions.