### PR TITLE
Fixed doc for dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ By default, Ignition uses a nice white based theme. If this is too bright for yo
 
 ```php
 \Spatie\Ignition\Ignition::make()
-    ->useDarkMode()
+    ->setDarkMode(true)
     ->register();
 ```
 


### PR DESCRIPTION
Quick chore fix for you here:

The Readme specified to switch to dark mode, call `useDarkMode()`, but as noted in the deprecation warning, you need to use `setTheme('dark') instead. I've corrected this one-liner.