### PR TITLE
Avoid hidding outer dumps, _(debugbar)_

### DIFF
--- a/resources/views/errorPage.php
+++ b/resources/views/errorPage.php
@@ -7,7 +7,7 @@
 <head>
     <!-- Hide dumps asap -->
     <style>
-        pre.sf-dump {
+        #app pre.sf-dump {
             display: none !important;
         }
     </style>


### PR DESCRIPTION
Since everything happens inside `#app`, it shouldn't affect
https://github.com/spatie/ignition/blob/2e9d1508aad2a05a52ee68b5faa05c0316a5f176/resources/views/errorPage.php#L57