### PR TITLE
Add support for Trae editor in Ignition

### DIFF
--- a/src/Config/IgnitionConfig.php
+++ b/src/Config/IgnitionConfig.php
@@ -207,6 +207,10 @@ class IgnitionConfig implements Arrayable
                     'label' => 'Cursor',
                     'url' => 'cursor://file/%path:%line',
                 ],
+                'trae' => [
+                    'label' => 'Trae',
+                    'url' => 'trae://file/%path:%line',
+                ],
                 'atom' => [
                     'label' => 'Atom',
                     'url' => 'atom://core/open/file?filename=%path&line=%line',


### PR DESCRIPTION
This PR adds support for the Trae editor (a fork of VSCode).
Users can now select Trae as their preferred editor in Ignition.